### PR TITLE
Improvement for multi-core kernel building

### DIFF
--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -16,7 +16,7 @@ if [ "${1}" = "skip" ] ; then
 else
 	echo "Compiling kernel"
 	cp defconfig .config
-	make "$@" || exit 1
+	make -j$(nproc --all) "$@" || exit 1
 fi
 
 echo "Building new ramdisk"


### PR DESCRIPTION
Adds -j parameter to make tool for taking advantage of available cores in current system.

*Tests made in a virtual / power limited environment:

Original compilation time, with 1 thread building:

real	31m54,857s
user	29m1,622s
sys	4m24,097s

After, with 8 threads building (4 cores x 2 HyperThreading):

real	8m54,863s
user	54m11,961s
sys	7m38,980s